### PR TITLE
Add API docs and examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 yogadl.egg-info
 __pycache__
 .mypy_cache
+docs/site

--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,16 @@ all: check test
 check: black flake8 mypy
 
 black:
-	black --check yogadl
-	black --check tests
+	black --check yogadl tests
 
 flake8:
-	flake8 yogadl
-	flake8 tests
+	flake8 yogadl tests
 
 mypy:
-	mypy yogadl
-	mypy tests
+	mypy yogadl tests
 
 fmt:
-	black .
+	black yogadl tests
 
 TEST_EXPR ?= ""
 

--- a/NOTICE
+++ b/NOTICE
@@ -43,3 +43,23 @@ The derived work can be found in this file:
 
     - tests/performance/imagenet/test_imagenet.py
     - tests/performance/imagenet/resnet_preprocessing.py
+
+
+Tensorflow/docs
+Copyright 2018 The TensorFlow Authors.  All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+The derived work can be found in this file:
+
+    - examples/minst.py

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A better approach to data loading for Deep Learning.  API-transparent caching to
 
 ## Why `yogadl`?
 
-At Determined AI, we help many customers perform high-performance data loading for deep learning
-models.  We believe every data loader should have two layers: the **random-access layer** and the
-**sequential layer**.
+At [Determined AI](https://determined.ai), we help many of our customers perform high-performance data
+loading for deep learning models.  We believe every data loader should have two layers: the
+**random-access layer** and the **sequential layer**.
 
 The **random-access layer** is critical for good training infrastructure.  Direct random access to
 any record enables:
@@ -133,6 +133,13 @@ First-class support for (tf.)Keras `Sequence` objects, PyTorch `DataSet` objects
 `yogadl` offers basic dataset versioning, but it is not (at this time) a full-blown version control
 for datasets.  Offering something like version control for datasets is on the roadmap as well.
 
-<!-- ## How do I use `yogadl`? -->
+## Installing `yogadl`
 
-<!-- TODO: code examples here. -->
+`yogadl` can be installed via `pip install yogadl`.
+
+## Further Information
+
+Please refer to the following links for more information:
+ - [YogaDL official documentation](https://yogadl.readthedocs.io/)
+ - [YogaDL examples](https://yogadl.readthedocs.io/examples)
+ - [YogaDL API Reference](https://yogadl.readthedocs.io/api)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,18 @@
+SPHINXOPTS    = -W
+SPHINXBUILD   = sphinx-build
+
+.PHONY: build
+build: sp-html
+
+.PHONY: clean
+clean:
+	rm -rf site
+
+live:
+	npx nodemon --ext txt --exec "$(MAKE) build" --ignore site
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+.PHONY: ALWAYS
+sp-%: ALWAYS
+	@$(SPHINXBUILD) -M $* . site $(SPHINXOPTS) $(O)

--- a/docs/api.txt
+++ b/docs/api.txt
@@ -1,0 +1,9 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+   :name: api_reference
+
+   yogadl
+   storage

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,114 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import pathlib
+import sys
+
+import determined_ai_sphinx_theme
+
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
+
+# -- Project information -----------------------------------------------------
+
+project = "YogaDL"
+html_title = "YogaDL Documentation"
+copyright = "2020, Determined AI"
+author = "hello@determined.ai"
+
+# The version info for the project you"re documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = "0.1"
+
+# The full version, including alpha/beta/rc tags.
+release = version
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.extlinks",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinxarg.ext",
+    # "sphinx_gallery.gen_gallery",
+    "sphinx_copybutton",
+    "m2r",
+]
+
+autosummary_generate = True
+autoclass_content = "class"
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also effect to html_static_path and html_extra_path
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "examples", "requirements.txt"]
+
+# The suffix of source filenames.
+source_suffix = {".rst": "restructuredtext", ".txt": "restructuredtext"}
+
+highlight_language = "none"
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named 'default.css' will overwrite the builtin 'default.css'.
+# html_static_path = ["_static"]
+
+# -- HTML theme settings ------------------------------------------------
+
+html_show_sourcelink = False
+html_show_sphinx = False
+html_last_updated_fmt = None
+# html_sidebars = {"**": ["logo-text.html", "globaltoc.html", "localtoc.html", "searchbox.html"]}
+
+html_theme_path = [determined_ai_sphinx_theme.get_html_theme_path()]
+html_theme = "determined_ai_sphinx_theme"
+# html_logo = "assets/images/logo.png"
+# html_favicon = "assets/images/favicon.ico"
+
+html_theme_options = {
+    "analytics_id": "UA-110089850-1",
+    "collapse_navigation": False,
+    "display_version": True,
+    "logo_only": False,
+}
+
+language = "en"
+
+todo_include_todos = True
+
+html_use_index = True
+html_domain_indices = True
+
+# -- Sphinx Gallery settings -------------------------------------------
+
+sphinx_gallery_conf = {
+    # Subsections are sorted by number of code lines per example. Override this
+    # to sort via the explicit ordering.
+    # "within_subsection_order": CustomOrdering,
+    # "download_all_examples": True,
+    "plot_gallery": False,
+    "min_reported_time": float("inf"),
+}

--- a/docs/examples.txt
+++ b/docs/examples.txt
@@ -1,0 +1,156 @@
+Examples
+========
+
+The following examples will walk you through the core concepts of YogaDL:
+storing, fetching, and streaming datasets.
+
+
+Creating a yogadl.Storage
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Most users will interact with :class:`yogadl.Storage` object as a mechanism for
+storing and fetching datasets. The simplest ``Storage`` is the
+:class:`yogadl.storage.LFSStorage`, or "local filesystem storage". Let's create
+one:
+
+.. literalinclude:: ../examples/walkthrough.py
+   :language: python
+   :start-after: START creating a yogadl.Storage
+   :end-before: END creating a yogadl.Storage
+
+YogaDL also comes with built-in support for GCS via
+:class:`yogadl.storage.GCSStorage` and for S3 via
+:class:`yogadl.storage.S3Storage`.
+
+Storing a dataset
+^^^^^^^^^^^^^^^^^
+
+Let's create a silly 10-record dataset and store it in the ``yogadl.Storage``.
+This is done via ``storage.submit()``. During ``storage.submit()``, the entire
+dataset will be read and written to the storage backend (in this case, to a
+file).
+
+.. literalinclude:: ../examples/walkthrough.py
+   :language: python
+   :start-after: START storing a dataset
+   :end-before: END storing a dataset
+
+
+Fetching a dataset
+^^^^^^^^^^^^^^^^^^
+
+Later (possibly in a different process), you can fetch a
+:class:`yogadl.DataRef` representing the dataset via ``storage.fetch()``.
+
+A ``DataRef`` is just a reference to a dataset. In this case, the dataset will
+be stored in a file on your computer, but a ``DataRef`` could just as easily
+refer to a dataset on some remote machine; the interface would be the same.
+
+To actually access the dataset, you need to first call ``dataref.stream()``,
+which will return a :class:`yogadl.Stream` object. Then you can convert the
+``Stream`` object to a framework-native data loader format (currently only
+``tf.data.Dataset`` is supported).
+
+.. literalinclude:: ../examples/walkthrough.py
+   :language: python
+   :start-after: START fetching a dataset
+   :end-before: END fetching a dataset
+
+This should print:
+
+.. code::
+
+    tf.Tensor([5 1 9 6 7], shape=(5,), dtype=int64)
+    tf.Tensor([1 7 3 9 8], shape=(5,), dtype=int64)
+    tf.Tensor([2 6 0 4 5], shape=(5,), dtype=int64)
+    tf.Tensor([9 5 3 0 8], shape=(5,), dtype=int64)
+    tf.Tensor([6 7 4 1 2], shape=(5,), dtype=int64)
+
+Notice that:
+
+ - The start_offset is only applied to the first epoch, so in this example
+   .repeat(3) gave us 2.5 epochs of data since we skipped the first epoch.
+ - The shuffle is a true shuffle. The shuffled stream samples from the whole
+   dataset without any concept of a "buffer", as with
+   ``tf.data.Dataset.shuffle()``
+ - The shuffle is reproducible because we chose a shuffle seed.
+ - Each epoch is reshuffled.
+
+
+Can I get the same features in fewer steps?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As a matter of fact, you can! In order to support the common use-case of
+running the same dataset through many different models during model development
+or hyperparameter search, you can use the ``storage.cacheable()`` decorator to
+decorate a function that returns a datastet.
+
+When the decorated function is called the first time, it will run one time and
+save its output to ``storage``. On subsequent calls, the original function
+will not run, but its cached output will be returned instead.
+
+In this way, you can get the benefit of caching without a single script and
+only a single call against the ``storage`` object:
+
+.. literalinclude:: ../examples/walkthrough.py
+   :language: python
+   :start-after: START can I get the same features in fewer steps?
+   :end-before: END can I get the same features in fewer steps?
+
+The ``storage.cacheble()`` decorator is multi-processing safe, so if two
+identical processes are configured to use the same storage, only one of them
+will create and save the dataset. The other one will wait for the dataset to
+be saved and will then read the dataset from the cache.
+
+
+End-to-end training example:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Here is an example of how you might use YogaDL to train on the second half of
+an MNIST dataset. This illustrates the ability to continue training mid-dataset
+that is simply not natively possible with tf.keras. Without YogaDL, you could
+imitate this behavior using ``tf.data.Dataset.skip(N)``, but that is
+prohibitively expensive for large values of ``N``.
+
+.. note::
+
+   MNIST is such a small dataset that YogaDL is not going to outperform
+   any example that treats MNIST as an in-memory dataset.
+
+.. literalinclude:: ../examples/mnist.py
+   :language: python
+   :start-after: INCLUDE IN DOCS
+
+
+Advanced Use Case: Distributed Training
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sharding a dataset for use with distributed training is easy. If you are using
+Horovod for distributed training, you only need to alter the arguments of your
+call to ``DataRef.stream()``.
+
+.. code:: python
+
+    import horovod.tensorflow as hvd
+
+    ...
+
+    stream = dataref.stream(
+        shard_rank=hvd.rank(), num_shards=hvd.size()
+    )
+
+
+Advanced Use Case: Custom DataRef Objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have an advanced use case, like generating data on an external machine
+and streaming it to another machine for training or something, and you would
+like to integrate with a platform that allows you to submit your dataset as a
+``yogadl.DataRef``, you can implement a custom :class:`yogadl.DataRef`. By
+implementing the ``yogadl.DataRef`` interface, you can fully customize the
+behavior of how the platform interacts with your dataset. Here is a toy example
+of what that might look like:
+
+.. literalinclude:: ../examples/custom_data_ref.py
+   :language: python
+   :start-after: INCLUDE IN DOCS

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -1,0 +1,8 @@
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   api
+   examples
+
+.. mdinclude:: ../README.md

--- a/docs/storage.txt
+++ b/docs/storage.txt
@@ -1,0 +1,23 @@
+yogadl.storage
+==============
+
+.. autoclass:: yogadl.storage.LFSConfigurations
+   :noindex:
+
+.. autoclass:: yogadl.storage.LFSStorage
+   :noindex:
+   :members:
+
+.. autoclass:: yogadl.storage.S3Configurations
+   :noindex:
+
+.. autoclass:: yogadl.storage.S3Storage
+   :noindex:
+   :inherited-members:
+
+.. autoclass:: yogadl.storage.GCSConfigurations
+   :noindex:
+
+.. autoclass:: yogadl.storage.GCSStorage
+   :noindex:
+   :inherited-members:

--- a/docs/yogadl.txt
+++ b/docs/yogadl.txt
@@ -1,0 +1,14 @@
+yogadl
+======
+
+.. autoclass:: yogadl.Stream
+   :noindex:
+   :members: __iter__, __len__
+
+.. autoclass:: yogadl.DataRef
+   :noindex:
+   :members: stream, __len__
+
+.. autoclass:: yogadl.Storage
+   :noindex:
+   :members:

--- a/examples/custom_data_ref.py
+++ b/examples/custom_data_ref.py
@@ -1,0 +1,92 @@
+# Copyright 2020 Determined AI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+If you have an advanced use case, like generating data on an external machine
+and streaming it to another machine for training or something, and you would
+like to integrate with a platform that allows you to submit your dataset as a
+``yogadl.DataRef``, you can implement a custom ``yogadl.DataRef``. By
+implementing the ``yogadl.DataRef`` interface, you can fully customize the
+behavior of how the platform interacts with your dataset. Here is a toy example
+of what that might look like:
+"""
+
+# INCLUDE IN DOCS
+import os
+import yogadl
+import yogadl.tensorflow
+import tensorflow as tf
+
+class RandomDataRef(yogadl.DataRef):
+    """
+    A DataRef to a a non-reproducible dataset that just produces random
+    int32 values.
+    """
+
+    def __len__(self):
+        return 10
+
+    def stream(
+        self,
+        start_offset = 0,
+        shuffle = False,
+        skip_shuffle_at_epoch_end = False,
+        shuffle_seed = None,
+        shard_rank = 0,
+        num_shards = 1,
+        drop_shard_remainder = False,
+    ) -> yogadl.Stream:
+        """
+        For custom DataRefs, .stream() will often be a pretty beefy
+        function. This example simplifies it by assuming that the dataset
+        is non-reproducible, meaning that shuffle and shuffle_seed
+        arguments are meaningless, and the shard_rank is only used to
+        determine how many records will be yielded during each epoch.
+        """
+
+        first_epoch = True
+
+        def iterator_fn():
+            nonlocal first_epoch
+            if first_epoch:
+                first_epoch = False
+                start = start_offset + shard_rank
+            else:
+                start = shard_rank
+
+            if drop_shard_remainder:
+                end = len(self) - (len(self) % num_shards)
+            else:
+                end = len(self)
+
+            for _ in range(start, end, num_shards):
+                # Make a uint32 out of 4 random bytes
+                r = os.urandom(4)
+                yield r[0] + (r[1] << 8) + (r[2] << 16) + (r[3] << 24)
+
+        # Since we will later convert to tf.data.Dataset,
+        # we will supply output_types and shapes.
+        return yogadl.Stream(
+            iterator_fn,
+            len(self),
+            output_types=tf.uint32,
+            output_shapes=tf.TensorShape([])
+        )
+
+dataref = RandomDataRef()
+stream = dataref.stream()
+records = yogadl.tensorflow.make_tf_dataset(stream)
+batches = records.batch(5)
+for batch in batches:
+    print(batch)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -1,0 +1,105 @@
+# Copyright 2020 Determined AI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# `normalize_img()` and the model definition are derived from the TensorFlow
+# documentation: https://www.tensorflow.org/datasets/keras_example
+#
+# Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+End-to-end training example:
+
+Here is an example of how you might use YogaDL to train on the second half of
+an MNIST dataset. This illustrates the ability to continue training mid-dataset
+that is simply not natively possible with tf.keras. Without YogaDL, you could
+imitate this behavior using tf.data.Dataset.skip(N), but that is
+prohibitively expensive for large values of N.
+"""
+
+# INCLUDE IN DOCS
+import math
+import os
+import tensorflow as tf
+import tensorflow_datasets as tfds
+import yogadl
+import yogadl.tensorflow
+import yogadl.storage
+
+BATCH_SIZE = 32
+
+# Configure the yogadl storage.
+storage_path = "/tmp/yogadl_cache"
+os.makedirs(storage_path, exist_ok=True)
+lfs_config = yogadl.storage.LFSConfigurations(storage_path)
+storage = yogadl.storage.LFSStorage(lfs_config)
+
+@storage.cacheable("mnist", "1.0")
+def make_data():
+    mnist = tfds.image.MNIST()
+    mnist.download_and_prepare()
+    dataset = mnist.as_dataset(as_supervised=True)["train"]
+
+    # Apply dataset transformations from the TensorFlow docs:
+    # (https://www.tensorflow.org/datasets/keras_example)
+
+    def normalize_img(image, label):
+        """Normalizes images: `uint8` -> `float32`."""
+        return tf.cast(image, tf.float32) / 255., label
+
+    return dataset.map(normalize_img)
+
+# Get the DataRef from the storage via the decorated function.
+dataref = make_data()
+
+# Stream the dataset starting halfway through it.
+num_batches = math.ceil(len(dataref) / BATCH_SIZE)
+batches_to_skip = num_batches // 2
+records_to_skip = batches_to_skip * BATCH_SIZE
+stream = dataref.stream(
+    start_offset=records_to_skip, shuffle=True, shuffle_seed=777
+)
+
+# Convert the stream to a tf.data.Dataset object.
+dataset = yogadl.tensorflow.make_tf_dataset(stream)
+
+# Apply normal data augmentation and prefetch steps.
+dataset = dataset.batch(BATCH_SIZE)
+dataset = dataset.prefetch(tf.data.experimental.AUTOTUNE)
+
+# Model is straight from the TensorFlow docs:
+# https://www.tensorflow.org/datasets/keras_example
+model = tf.keras.models.Sequential([
+  tf.keras.layers.Flatten(input_shape=(28, 28, 1)),
+  tf.keras.layers.Dense(128,activation='relu'),
+  tf.keras.layers.Dense(10, activation='softmax')
+])
+model.compile(
+    loss='sparse_categorical_crossentropy',
+    optimizer=tf.keras.optimizers.Adam(0.001),
+    metrics=['accuracy'],
+)
+model.fit(dataset)

--- a/examples/walkthrough.py
+++ b/examples/walkthrough.py
@@ -1,0 +1,83 @@
+# Copyright 2020 Determined AI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""
+This file contains the code snippets which are used in the Examples section of
+the documentation. It is compiled in one place here for testing purposes.
+
+The START and END comments denote sections of this file which will become code
+snippets in the documentation.
+"""
+
+# START creating a yogadl.Storage
+import os
+import yogadl
+import yogadl.storage
+
+# Create a yogadl.Storage object backed by the local filesystem.
+storage_path = "/tmp/yogadl_cache"
+os.makedirs(storage_path, exist_ok=True)
+lfs_config = yogadl.storage.LFSConfigurations(storage_path)
+storage = yogadl.storage.LFSStorage(lfs_config)
+# END creating a yogadl.Storage
+
+
+# START storing a dataset
+import tensorflow as tf
+
+# Create a dataset we can store.
+records = tf.data.Dataset.range(10)
+
+# Store this dataset as "range" version "1.0".
+storage.submit(records, "range", "1.0")
+# END storing a dataset
+
+
+# START fetching a dataset
+import yogadl.tensorflow
+
+# Get the DataRef.
+dataref = storage.fetch("range", "1.0")
+
+# Tell the DataRef how to stream the dataset.
+stream = dataref.stream(start_offset=5, shuffle=True, shuffle_seed=777)
+
+# Interpret the stream as a tensorflow dataset
+records = yogadl.tensorflow.make_tf_dataset(stream)
+
+# It's a real tf.data.Dataset; you can use normal tf.data operations on it.
+batches = records.repeat(3).batch(5)
+
+# (this part requires TensorFlow >= 2.0)
+for batch in batches:
+    print(batch)
+# END fetching a dataset
+
+
+# START can I get the same features in fewer steps?
+@storage.cacheable("range", "2.0")
+def make_records():
+    print("Cache not found, making range v2 dataset...")
+    records = tf.data.Dataset.range(10).map(lambda x: 2*x)
+    return records
+
+# Follow the same steps as before.
+dataref = make_records()
+stream = dataref.stream()
+records = yogadl.tensorflow.make_tf_dataset(stream)
+batches = records.repeat(3).batch(5)
+
+for batch in batches:
+    print(batch)
+# END can I get the same features in fewer steps?

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+    - method: pip
+      path: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,12 @@ pytest
 tensorflow_datasets<2
 tl.testing
 pytest
+
+docutils==0.15.2
+sphinx==2.4.4
+sphinx-argparse>=0.2.5
+git+https://github.com/determined-ai/determined_sphinx_theme.git@accf3fbb639c88deb2e60293bdd15b3cae3afc01
+sphinx-gallery>=0.6.1
+pillow
+sphinx-copybutton
+m2r

--- a/tests/integration/local/test_examples.py
+++ b/tests/integration/local/test_examples.py
@@ -1,0 +1,33 @@
+# Copyright 2020 Determined AI. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import pathlib
+import runpy
+
+
+def examples_dir() -> pathlib.Path:
+    here = pathlib.Path(__file__).parent
+    return here.parent.parent.parent.joinpath("examples")
+
+
+def test_walkthrough() -> None:
+    runpy.run_path(str(examples_dir().joinpath("walkthrough.py")))
+
+
+def test_mnist() -> None:
+    runpy.run_path(str(examples_dir().joinpath("mnist.py")))
+
+
+def test_custom_data_ref() -> None:
+    runpy.run_path(str(examples_dir().joinpath("custom_data_ref.py")))

--- a/yogadl/_core.py
+++ b/yogadl/_core.py
@@ -48,9 +48,15 @@ class Stream:
         self.output_shapes = output_shapes
 
     def __iter__(self) -> Any:
+        """
+        Iterate through the records in the stream.
+        """
         return self.iterator_fn()
 
     def __len__(self) -> int:
+        """
+        Return the length of the stream, which may differ from the length of the dataset.
+        """
         return self.length
 
 
@@ -78,10 +84,17 @@ class DataRef(metaclass=abc.ABCMeta):
         num_shards: int = 1,
         drop_shard_remainder: bool = False,
     ) -> Stream:
+        """
+        Create a sequentially accessible set of records from the dataset, according to the
+        random-access arguments given as parameters.
+        """
         pass
 
     @abc.abstractmethod
     def __len__(self) -> int:
+        """
+        Return the length of the dataset that the DataRef refers to.
+        """
         pass
 
 


### PR DESCRIPTION
Totally open to changing where we host these, but I've been imagining we would host them at docs.determined.ai/yogadl

To view  the changes, you should install the new sphinx dependencies, then `make -C docs build`, then open `/path/to/yogadl/docs/site/html/index.html` in your browser.