### PR TITLE
feat: allow configuring certificate verification for TLS connections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ README = (HERE / "README.md").read_text()
 
 setup(
     name="yogadl",
-    version="0.1.1",
+    version="0.1.2",
     author="Determined AI",
     author_email="hello@determined.ai",
     url="https://www.github.com/determined-ai/yogadl/",

--- a/tests/unit/aws/test_s3_storage.py
+++ b/tests/unit/aws/test_s3_storage.py
@@ -75,7 +75,9 @@ def test_s3_storage_submit() -> None:
 
     client = boto3.client("s3")
     aws_cache_filepath = get_s3_filepath(
-        configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+        configurations=configurations,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
 
     try:
@@ -86,7 +88,9 @@ def test_s3_storage_submit() -> None:
 
     s3_storage = storage.S3Storage(configurations=configurations)
     s3_storage.submit(
-        data=dataset, dataset_id=dataset_id, dataset_version=dataset_version,
+        data=dataset,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
 
     blob_info = client.head_object(Bucket=configurations.bucket, Key=str(aws_cache_filepath))
@@ -106,12 +110,16 @@ def test_s3_storage_local_metadata() -> None:
 
     client = boto3.client("s3")
     aws_cache_filepath = get_s3_filepath(
-        configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+        configurations=configurations,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
 
     s3_storage = storage.S3Storage(configurations=configurations)
     s3_storage.submit(
-        data=dataset, dataset_id=dataset_id, dataset_version=dataset_version,
+        data=dataset,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
 
     local_metadata_filepath = get_local_metadata_filepath(
@@ -144,7 +152,9 @@ def test_s3_storage_submit_and_fetch() -> None:
 
     s3_storage = storage.S3Storage(configurations=configurations)
     s3_storage.submit(
-        data=dataset, dataset_id=dataset_id, dataset_version=dataset_version,
+        data=dataset,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
     dataref = s3_storage.fetch(dataset_id=dataset_id, dataset_version=dataset_version)
     stream = dataref.stream()
@@ -169,7 +179,9 @@ def test_s3_storage_cacheable_single_threaded() -> None:
     access_server_handler.run_server_in_thread()
 
     s3_cache_filepath = get_s3_filepath(
-        configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+        configurations=configurations,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
     client = boto3.client("s3")
     client.delete_object(Bucket=configurations.bucket, Key=str(s3_cache_filepath))
@@ -225,7 +237,9 @@ class MultiThreadedTests(thread.ThreadAwareTestCase):  # type: ignore
         access_server_handler.run_server_in_thread()
 
         s3_cache_filepath = get_s3_filepath(
-            configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+            configurations=configurations,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         client = boto3.client("s3")
         client.delete_object(Bucket=configurations.bucket, Key=str(s3_cache_filepath))

--- a/tests/unit/gcp/test_gcs_storage.py
+++ b/tests/unit/gcp/test_gcs_storage.py
@@ -75,7 +75,9 @@ def test_gcs_storage_submit() -> None:
     client = google_storage.Client()
     bucket = client.bucket(configurations.bucket)
     gcs_cache_filepath = get_gcs_filepath(
-        configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+        configurations=configurations,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
     blob = bucket.blob(str(gcs_cache_filepath))
 
@@ -86,7 +88,9 @@ def test_gcs_storage_submit() -> None:
 
     gcs_storage = storage.GCSStorage(configurations=configurations)
     gcs_storage.submit(
-        data=dataset, dataset_id=dataset_id, dataset_version=dataset_version,
+        data=dataset,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
 
     blob = bucket.blob(str(gcs_cache_filepath))
@@ -109,12 +113,16 @@ def test_gcs_storage_local_metadata() -> None:
     client = google_storage.Client()
     bucket = client.bucket(configurations.bucket)
     gcs_cache_filepath = get_gcs_filepath(
-        configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+        configurations=configurations,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
 
     gcs_storage = storage.GCSStorage(configurations=configurations)
     gcs_storage.submit(
-        data=dataset, dataset_id=dataset_id, dataset_version=dataset_version,
+        data=dataset,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
 
     local_metadata_filepath = get_local_metadata_filepath(
@@ -147,7 +155,9 @@ def test_gcs_storage_submit_and_fetch() -> None:
 
     gcs_storage = storage.GCSStorage(configurations=configurations)
     gcs_storage.submit(
-        data=dataset, dataset_id=dataset_id, dataset_version=dataset_version,
+        data=dataset,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
     dataref = gcs_storage.fetch(dataset_id=dataset_id, dataset_version=dataset_version)
     stream = dataref.stream()
@@ -172,7 +182,9 @@ def test_gcs_storage_cacheable_single_threaded() -> None:
     access_server_handler.run_server_in_thread()
 
     gcs_cache_filepath = get_gcs_filepath(
-        configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+        configurations=configurations,
+        dataset_id=dataset_id,
+        dataset_version=dataset_version,
     )
     client = google_storage.Client()
     bucket = client.bucket(configurations.bucket)
@@ -233,7 +245,9 @@ class MultiThreadedTests(thread.ThreadAwareTestCase):  # type: ignore
         access_server_handler.run_server_in_thread()
 
         gcs_cache_filepath = get_gcs_filepath(
-            configurations=configurations, dataset_id=dataset_id, dataset_version=dataset_version,
+            configurations=configurations,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         client = google_storage.Client()
         bucket = client.bucket(configurations.bucket)

--- a/yogadl/dataref/_local_lmdb_dataref.py
+++ b/yogadl/dataref/_local_lmdb_dataref.py
@@ -43,7 +43,9 @@ class LMDBDataRef(yogadl.DataRef):
             )
 
         generated_keys = self._shard_keys(
-            shard_rank=shard_rank, num_shards=num_shards, drop_shard_remainder=drop_shard_remainder,
+            shard_rank=shard_rank,
+            num_shards=num_shards,
+            drop_shard_remainder=drop_shard_remainder,
         )
 
         generator_from_keys = yogadl.GeneratorFromKeys(

--- a/yogadl/rw_coordinator/_client.py
+++ b/yogadl/rw_coordinator/_client.py
@@ -62,7 +62,10 @@ class RwCoordinatorClient:
         self, storage_type: str, bucket: str, cache_path: pathlib.Path
     ) -> Generator[None, None, None]:
         lock_request_url = self._construct_url_request(
-            storage_type=storage_type, bucket=bucket, cache_path=cache_path, read_lock=True,
+            storage_type=storage_type,
+            bucket=bucket,
+            cache_path=cache_path,
+            read_lock=True,
         )
 
         try:
@@ -80,7 +83,10 @@ class RwCoordinatorClient:
         self, storage_type: str, bucket: str, cache_path: pathlib.Path
     ) -> Generator[None, None, None]:
         lock_request_url = self._construct_url_request(
-            storage_type=storage_type, bucket=bucket, cache_path=cache_path, read_lock=False,
+            storage_type=storage_type,
+            bucket=bucket,
+            cache_path=cache_path,
+            read_lock=False,
         )
 
         try:

--- a/yogadl/storage/_cloud_storage.py
+++ b/yogadl/storage/_cloud_storage.py
@@ -33,7 +33,11 @@ class BaseCloudConfigurations(metaclass=abc.ABCMeta):
     """
 
     def __init__(
-        self, bucket: str, bucket_directory_path: str, url: str, local_cache_dir: str,
+        self,
+        bucket: str,
+        bucket_directory_path: str,
+        url: str,
+        local_cache_dir: str,
     ) -> None:
         self.bucket = bucket
         self.bucket_directory_path = pathlib.Path(bucket_directory_path)
@@ -97,7 +101,8 @@ class BaseCloudStorage(yogadl.Storage):
         `cacheable()`.
         """
         local_cache_filepath = self._get_local_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         local_cache_filepath.parent.mkdir(parents=True, exist_ok=True)
 
@@ -128,7 +133,9 @@ class BaseCloudStorage(yogadl.Storage):
 
         local_metadata["time_created"] = timestamp
         self._save_local_metadata(
-            dataset_id=dataset_id, dataset_version=dataset_version, metadata=local_metadata,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
+            metadata=local_metadata,
         )
 
     def fetch(self, dataset_id: str, dataset_version: str) -> dataref.LMDBDataRef:
@@ -147,7 +154,8 @@ class BaseCloudStorage(yogadl.Storage):
             dataset_id=dataset_id, dataset_version=dataset_version
         )
         local_cache_filepath = self._get_local_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
         remote_cache_timestamp = self._get_remote_cache_timestamp(
@@ -166,7 +174,9 @@ class BaseCloudStorage(yogadl.Storage):
             logging.info("Cache download finished.")
 
             self._save_local_metadata(
-                dataset_id=dataset_id, dataset_version=dataset_version, metadata=local_metadata,
+                dataset_id=dataset_id,
+                dataset_version=dataset_version,
+                metadata=local_metadata,
             )
 
         assert local_cache_filepath.exists()
@@ -224,7 +234,8 @@ class BaseCloudStorage(yogadl.Storage):
         ):
             if self._is_cloud_cache_present(dataset_id=dataset_id, dataset_version=dataset_version):
                 with self._lock_local_cache(
-                    dataset_id=dataset_id, dataset_version=dataset_version,
+                    dataset_id=dataset_id,
+                    dataset_version=dataset_version,
                 ):
                     local_lmdb_dataref = self.fetch(
                         dataset_id=dataset_id, dataset_version=dataset_version
@@ -233,7 +244,12 @@ class BaseCloudStorage(yogadl.Storage):
         return local_lmdb_dataref
 
     def _try_writing_to_cloud_storage(
-        self, dataset_id: str, dataset_version: str, f: Callable, args: Any, kwargs: Any,
+        self,
+        dataset_id: str,
+        dataset_version: str,
+        f: Callable,
+        args: Any,
+        kwargs: Any,
     ) -> None:
         remote_cache_path = self._get_remote_cache_filepath(
             dataset_id=dataset_id, dataset_version=dataset_version
@@ -249,7 +265,8 @@ class BaseCloudStorage(yogadl.Storage):
                 dataset_id=dataset_id, dataset_version=dataset_version
             ):
                 with self._lock_local_cache(
-                    dataset_id=dataset_id, dataset_version=dataset_version,
+                    dataset_id=dataset_id,
+                    dataset_version=dataset_version,
                 ):
                     self.submit(
                         data=f(*args, **kwargs),
@@ -303,7 +320,8 @@ class BaseCloudStorage(yogadl.Storage):
 
     def _get_local_metadata(self, dataset_id: str, dataset_version: str) -> Dict[str, Any]:
         metadata_filepath = self._get_local_metadata_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
         if not metadata_filepath.exists():
@@ -316,7 +334,8 @@ class BaseCloudStorage(yogadl.Storage):
         self, dataset_id: str, dataset_version: str, metadata: Dict[str, Any]
     ) -> None:
         metadata_filepath = self._get_local_metadata_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
         with open(str(metadata_filepath), "w") as metadata_file:

--- a/yogadl/storage/_cloud_storage.py
+++ b/yogadl/storage/_cloud_storage.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 import abc
-import datetime
 import contextlib
+import datetime
 import json
 import logging
 import pathlib
-from typing import Any, Callable, cast, Dict, Generator, Optional
+from typing import Any, Callable, Dict, Generator, Optional, cast
 
 import filelock
 import tensorflow as tf
@@ -38,12 +38,16 @@ class BaseCloudConfigurations(metaclass=abc.ABCMeta):
         bucket_directory_path: str,
         url: str,
         local_cache_dir: str,
+        skip_verify: bool,
+        coordinator_cert_file: Optional[str],
     ) -> None:
         self.bucket = bucket
         self.bucket_directory_path = pathlib.Path(bucket_directory_path)
         self.url = url
         self.local_cache_dir = pathlib.Path(local_cache_dir)
         self.cache_format = "LMDB"
+        self.skip_verify = skip_verify
+        self.coordinator_cert_file = coordinator_cert_file
 
 
 class BaseCloudStorage(yogadl.Storage):
@@ -60,7 +64,11 @@ class BaseCloudStorage(yogadl.Storage):
         tensorflow_config: Optional[tf.compat.v1.ConfigProto],
     ) -> None:
         self._configurations = configurations
-        self._rw_client = rw_coordinator.RwCoordinatorClient(url=self._configurations.url)
+        self._rw_client = rw_coordinator.RwCoordinatorClient(
+            url=self._configurations.url,
+            skip_verify=self._configurations.skip_verify,
+            coordinator_cert_file=self._configurations.coordinator_cert_file,
+        )
         self._supported_cache_formats = ["LMDB"]
         self._tensorflow_config = tensorflow_config
 

--- a/yogadl/storage/_gcs_storage.py
+++ b/yogadl/storage/_gcs_storage.py
@@ -26,7 +26,11 @@ from yogadl import storage
 
 class GCSConfigurations(storage.BaseCloudConfigurations):
     def __init__(
-        self, bucket: str, bucket_directory_path: str, url: str, local_cache_dir: str = "/tmp/",
+        self,
+        bucket: str,
+        bucket_directory_path: str,
+        url: str,
+        local_cache_dir: str = "/tmp/",
     ) -> None:
         super().__init__(
             bucket=bucket,
@@ -82,7 +86,8 @@ class GCSStorage(storage.BaseCloudStorage):
     def _is_cloud_cache_present(self, dataset_id: str, dataset_version: str) -> bool:
 
         gcs_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         blob = self._bucket.blob(str(gcs_cache_filepath))
 
@@ -96,7 +101,8 @@ class GCSStorage(storage.BaseCloudStorage):
     ) -> datetime.datetime:
 
         gcs_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         blob = self._bucket.blob(str(gcs_cache_filepath))
 
@@ -121,7 +127,8 @@ class GCSStorage(storage.BaseCloudStorage):
     ) -> datetime.datetime:
 
         gcs_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         blob = self._bucket.blob(str(gcs_cache_filepath))
 
@@ -144,7 +151,8 @@ class GCSStorage(storage.BaseCloudStorage):
     ) -> datetime.datetime:
 
         gcs_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         blob = self._bucket.blob(str(gcs_cache_filepath))
 

--- a/yogadl/storage/_gcs_storage.py
+++ b/yogadl/storage/_gcs_storage.py
@@ -31,12 +31,16 @@ class GCSConfigurations(storage.BaseCloudConfigurations):
         bucket_directory_path: str,
         url: str,
         local_cache_dir: str = "/tmp/",
+        skip_verify: bool = False,
+        coordinator_cert_file: Optional[str] = None,
     ) -> None:
         super().__init__(
             bucket=bucket,
             bucket_directory_path=bucket_directory_path,
             url=url,
             local_cache_dir=local_cache_dir,
+            skip_verify=skip_verify,
+            coordinator_cert_file=coordinator_cert_file,
         )
 
 

--- a/yogadl/storage/_lfs_storage.py
+++ b/yogadl/storage/_lfs_storage.py
@@ -61,7 +61,8 @@ class LFSStorage(yogadl.Storage):
         If a cache with a matching filepath already exists, it will be overwritten.
         """
         cache_filepath = self._get_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
         cache_filepath.parent.mkdir(parents=True, exist_ok=True)
 

--- a/yogadl/storage/_s3_storage.py
+++ b/yogadl/storage/_s3_storage.py
@@ -34,12 +34,16 @@ class S3Configurations(storage.BaseCloudConfigurations):
         secret_key: Optional[str] = None,
         endpoint_url: Optional[str] = None,
         local_cache_dir: str = "/tmp/",
+        skip_verify: bool = False,
+        coordinator_cert_file: Optional[str] = None,
     ) -> None:
         super().__init__(
             bucket=bucket,
             bucket_directory_path=bucket_directory_path,
             url=url,
             local_cache_dir=local_cache_dir,
+            skip_verify=skip_verify,
+            coordinator_cert_file=coordinator_cert_file,
         )
         self.access_key = access_key
         self.secret_key = secret_key

--- a/yogadl/storage/_s3_storage.py
+++ b/yogadl/storage/_s3_storage.py
@@ -98,7 +98,8 @@ class S3Storage(storage.BaseCloudStorage):
     def _is_cloud_cache_present(self, dataset_id: str, dataset_version: str) -> bool:
 
         s3_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
         try:
@@ -114,7 +115,8 @@ class S3Storage(storage.BaseCloudStorage):
     ) -> datetime.datetime:
 
         s3_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
         try:
@@ -138,7 +140,8 @@ class S3Storage(storage.BaseCloudStorage):
     ) -> datetime.datetime:
 
         s3_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
         try:
@@ -151,7 +154,8 @@ class S3Storage(storage.BaseCloudStorage):
             raise AssertionError(f"Failed to upload file to S3 with exception: {error}.")
 
         return self._get_remote_cache_timestamp(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
     def _get_remote_cache_timestamp(
@@ -159,7 +163,8 @@ class S3Storage(storage.BaseCloudStorage):
     ) -> datetime.datetime:
 
         s3_cache_filepath = self._get_remote_cache_filepath(
-            dataset_id=dataset_id, dataset_version=dataset_version,
+            dataset_id=dataset_id,
+            dataset_version=dataset_version,
         )
 
         try:


### PR DESCRIPTION
In order to handle connecting to masters serving over TLS that don't
have certificates signed by widely recognized CAs, this adds
configurable verification to the WebSocket master connection, along with
the threading required to get the configuration where it needs to be.

The API is patterned after that of Requests: a new `verify` config
option can be `None` (the default) to use default system verification or
a string path to use the named file as the CA file. For simplicity,
setting the option to `False` to disable verification entirely is not
supported, since that scenario is currently not required by yogadl's
usage in Determined.